### PR TITLE
2.0.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'com.google.android.gms.oss-licenses-plugin'
 }
 
-def tagName = '2.0'
+def tagName = '2.0.1'
 
 android {
     compileSdk 32
@@ -16,7 +16,7 @@ android {
         applicationId "com.kieronquinn.app.pixellaunchermods"
         minSdk 31
         targetSdk 32
-        versionCode 200
+        versionCode 201
         versionName tagName
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+import org.apache.tools.ant.taskdefs.condition.Os
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
@@ -31,11 +32,26 @@ task cleanOverlay(type: Delete, dependsOn: ordered(':overlay:clean')) {
     delete 'overlay/module/system/product/overlay/PixelLauncherModsOverlay/PixelLauncherModsOverlay.apk'
 }
 
-task buildAndCopyOverlay(type: Copy, dependsOn: ordered(':overlay:packageReleaseUniversalApk')) {
+/**
+ *  Using `:overlay:assembleRelease` does not seem to work from the Studio-embedded Gradle.
+ *  Instead, we spawn a separate gradle for this small task.
+ */
+task assembleGradleDaemon(type: Exec) {
+    String gradleWrapper = ""
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        gradleWrapper = ".\\gradlew.bat"
+    }else{
+        gradleWrapper = "./gradlew"
+    }
+    workingDir "$projectDir"
+    commandLine gradleWrapper, ':overlay:assembleRelease'
+}
+
+task buildAndCopyOverlay(type: Copy, dependsOn: ordered(':assembleGradleDaemon')) {
     //Copy built APK into module folder
-    from "overlay/build/outputs/universal_apk/release/overlay-release-universal.apk"
+    from "overlay/build/outputs/apk/release/overlay-release.apk"
     into "overlay/module/system/product/overlay/PixelLauncherModsOverlay"
-    rename("overlay-release-universal.apk", "PixelLauncherModsOverlay.apk")
+    rename("overlay-release.apk", "PixelLauncherModsOverlay.apk")
 }
 
 task zipModule(type: Zip) {

--- a/overlay/build.gradle
+++ b/overlay/build.gradle
@@ -40,7 +40,6 @@ android {
             keyPassword "android"
 
             v1SigningEnabled true
-            v2SigningEnabled true
         }
     }
 


### PR DESCRIPTION
Fixed overlay signing issue that was leading to Magisk overlay issues

If you have previously used the Magisk overlay you MUST now uninstall it, reboot, and then save and re-install the new version, to prevent signature collisions. This only has to be done once.