### PR TITLE
2.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ plugins {
     id 'com.google.android.gms.oss-licenses-plugin'
 }
 
-def tagName = '2.1'
-def tagCode = 210
+def tagName = '2.2'
+def tagCode = 220
 
 android {
     compileSdk 32
@@ -54,7 +54,7 @@ android {
 dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'com.google.android.material:material:1.5.0'
+    implementation 'com.google.android.material:material:1.6.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"

--- a/app/src/main/aidl/com/kieronquinn/app/pixellaunchermods/service/IPixelLauncherModsRootService.aidl
+++ b/app/src/main/aidl/com/kieronquinn/app/pixellaunchermods/service/IPixelLauncherModsRootService.aidl
@@ -46,4 +46,7 @@ interface IPixelLauncherModsRootService {
     //Widget replacement
     void setSearchWidgetPackageEnabled(boolean enabled);
 
+    //Reset
+    void uninstallOverlayUpdates();
+
 }

--- a/app/src/main/java/com/kieronquinn/app/pixellaunchermods/repositories/IconLoaderRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/pixellaunchermods/repositories/IconLoaderRepository.kt
@@ -177,7 +177,6 @@ class IconLoaderRepositoryImpl(
             BitmapFactory.decodeByteArray(icon, 0, icon.size).run {
                 BitmapDrawable(context.resources, this)
             }
-
         } else null
     }
 
@@ -369,10 +368,6 @@ class IconLoaderRepositoryImpl(
                 val drawable = this.getMonochromeOrForeground()
                 scale = 1f + iconNormalizer.getScale(drawable, null, null, null)
                 drawable
-            }else this
-        }.run {
-            if(options.result.isLegacyThemedIcon() && this is AdaptiveIconDrawable) {
-                getMonochromeOrForeground()
             }else this
         }.run {
             glide.load(this).run {

--- a/app/src/main/java/com/kieronquinn/app/pixellaunchermods/service/PixelLauncherModsRootService.kt
+++ b/app/src/main/java/com/kieronquinn/app/pixellaunchermods/service/PixelLauncherModsRootService.kt
@@ -768,6 +768,10 @@ class PixelLauncherModsRootServiceImpl: IPixelLauncherModsRootService.Stub() {
         }
     }
 
+    override fun uninstallOverlayUpdates() {
+        execRootCommand("pm uninstall $OVERLAY_PACKAGE_NAME")
+    }
+
     override fun resetAllIcons(callback: IResetCompleteCallback) {
         GlobalScope.launch {
             withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/kieronquinn/app/pixellaunchermods/utils/extensions/Extensions+Resources.kt
+++ b/app/src/main/java/com/kieronquinn/app/pixellaunchermods/utils/extensions/Extensions+Resources.kt
@@ -12,10 +12,14 @@ fun Resources.isAdaptiveIcon(identifier: Int): Boolean {
 }
 
 fun Resources.rawResourceContains(identifier: Int, searchString: String): Boolean {
-    return openRawResource(identifier).use {
-        it.bufferedReader().use { reader ->
-            reader.readText().contains(searchString)
+    return try {
+        openRawResource(identifier).use {
+            it.bufferedReader().use { reader ->
+                reader.readText().contains(searchString)
+            }
         }
+    }catch (e: Resources.NotFoundException){
+        false
     }
 }
 

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -195,9 +195,9 @@
     <string name="reset_info_warning">Resetarea este ireversibilă. Asigurați-vă că ați făcut o copie de rezervă înainte de a continua, dacă doriți să păstrați configurația aplicației și comenzilor rapide ale aplicației</string>
     <string name="reset_info_title">Avertisment</string>
     <string name="reset_info_included">Resetarea va șterge</string>
-    <string name="reset_info_included_content">• Etichete și pictograme pentru aplicații modificate, atât tematice, cât și normale\n• Pictograme modificate pentru comenzile rapide pentru aplicații\n• Configurare automată a pachetului de pictograme</string>
+    <string name="reset_info_included_content">• Etichete și pictograme pentru aplicații modificate, atât tematice, cât și normale\n• Pictograme modificate pentru comenzile rapide pentru aplicații\n• Configurare automată a pachetului de pictograme\n• Configurarea aplicațiilor ascunse\n• Configurarea înlocuirii widget-ului</string>
     <string name="reset_info_not_included">Resetarea <b>nu</b> va șterge</string>
-    <string name="reset_info_not_included_content">%1s• Configurarea aplicațiilor ascunse\n• Configurarea înlocuirii widget-ului (atât aceasta cât și aplicațiile ascunse trebuie resetate separat)\n• Setările Pixel Launcher Mods, cum ar fi ascunderea ceasului sau a configurației Repornire fără întreruperi</string>
+    <string name="reset_info_not_included_content">%1s• Setările Pixel Launcher Mods, cum ar fi ascunderea ceasului sau a configurației Repornire fără întreruperi</string>
     <string name="reset_info_not_included_content_extra_shortcut">• Scurtăturile moștenite, cum ar fi ”%1s”\n</string>
     <string name="reset_info_continue">Continuați</string>
     <string name="reset_apply_title">Se resetează…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -211,9 +211,9 @@
     <string name="reset_info_warning">Resetting is irreversible. Make sure you have made a backup before continuing, if you wish to keep your app and app shortcut configuration</string>
     <string name="reset_info_title">Warning</string>
     <string name="reset_info_included">Resetting will delete</string>
-    <string name="reset_info_included_content">• Modified app labels and icons, both themed and normal\n• Modified app shortcut icons\n• Automatic icon pack configuration</string>
+    <string name="reset_info_included_content">• Modified app labels and icons, both themed and normal\n• Modified app shortcut icons\n• Automatic icon pack configuration\n• Hidden apps configuration\n• Widget replacement configuration</string>
     <string name="reset_info_not_included">Resetting will <b>not</b> delete</string>
-    <string name="reset_info_not_included_content">%1s• Hidden apps configuration\n• Widget replacement configuration (both this and hidden apps must be reset separately)\n• Your Pixel Launcher Mods settings, such as hiding the clock or the Seamless Restart configuration</string>
+    <string name="reset_info_not_included_content">%1s• Your Pixel Launcher Mods settings, such as hiding the clock or the Seamless Restart configuration</string>
     <string name="reset_info_not_included_content_extra_shortcut">• Legacy shortcuts, such as \"%1s\"\n</string>
     <string name="reset_info_continue">Continue</string>
     <string name="reset_apply_title">Resetting…</string>


### PR DESCRIPTION
- Fixed Widget Replacement crash on Android 13 B1
- Fixed icons not applying after grid size changes (#33)
- Fixed themed icons not having a background when applied to the app drawer (#32)
- The overlay will now be reset to the stub when resetting, allowing a clean Magisk module uninstall (#28)
- Fixed crashes (#29, #30)