### PR TITLE
2.2.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ plugins {
     id 'com.google.android.gms.oss-licenses-plugin'
 }
 
-def tagName = '2.2'
-def tagCode = 220
+def tagName = '2.2.1'
+def tagCode = 221
 
 android {
     compileSdk 32

--- a/app/src/main/java/com/kieronquinn/app/pixellaunchermods/repositories/IconLoaderRepository.kt
+++ b/app/src/main/java/com/kieronquinn/app/pixellaunchermods/repositories/IconLoaderRepository.kt
@@ -370,6 +370,10 @@ class IconLoaderRepositoryImpl(
                 drawable
             }else this
         }.run {
+            if(options.result.isLegacyThemedIcon() && options.mono && this is AdaptiveIconDrawable) {
+                getMonochromeOrForeground()
+            }else this
+        }.run {
             glide.load(this).run {
                 scale?.let {
                     transform(ScaleTransformation(it))


### PR DESCRIPTION
Fixed a bug introduced in 2.2 where the monochrome/themed icon would be solid when picked from an adaptive icon